### PR TITLE
Fixed the possibility to assign IP from an untrusted source

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.json  text eol=lf
+*.md    text eol=lf
+*.php   text eol=lf
+*.xml   text eol=lf
+*.yml   text eol=lf

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -108,11 +108,13 @@ class IpAddress
             $ipAddress = $serverParams['REMOTE_ADDR'];
         }
 
-        $checkProxyHeaders = $this->checkProxyHeaders;
-        if ($checkProxyHeaders && !empty($this->trustedProxies)) {
-            if (!in_array($ipAddress, $this->trustedProxies)) {
-                $checkProxyHeaders = false;
-            }
+        $checkProxyHeaders = false;
+
+        if ($this->checkProxyHeaders
+            && !empty($this->trustedProxies)
+            && in_array($ipAddress, $this->trustedProxies)
+        ) {
+            $checkProxyHeaders = true;
         }
 
         if ($checkProxyHeaders) {

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -108,16 +108,10 @@ class IpAddress
             $ipAddress = $serverParams['REMOTE_ADDR'];
         }
 
-        $checkProxyHeaders = false;
-
         if ($this->checkProxyHeaders
             && !empty($this->trustedProxies)
             && in_array($ipAddress, $this->trustedProxies)
         ) {
-            $checkProxyHeaders = true;
-        }
-
-        if ($checkProxyHeaders) {
             foreach ($this->headersToInspect as $header) {
                 if ($request->hasHeader($header)) {
                     $ip = $this->getFirstIpAddressFromHeader($request, $header);

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -48,7 +48,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
 
     public function testXForwardedForIp()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, ['192.168.1.1']);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -88,7 +88,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
 
     public function testHttpClientIp()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, ['192.168.1.1']);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -108,7 +108,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
 
     public function testXForwardedForIpV6()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, ['192.168.1.1']);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -128,7 +128,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
 
     public function testXForwardedForWithInvalidIp()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, ['192.168.1.1']);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -188,7 +188,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
 
     public function testForwardedWithMultipleFor()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, ['192.168.1.1']);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -208,7 +208,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
 
     public function testForwardedWithAllOptions()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, ['192.168.1.1']);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -228,7 +228,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
 
     public function testForwardedWithWithIpV6()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, ['192.168.1.1']);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -251,7 +251,7 @@ class RendererTest extends \PHPUnit_Framework_TestCase
         $headersToInspect = [
             'Foo-Bar'
         ];
-        $middleware = new IPAddress(true, [], null, $headersToInspect);
+        $middleware = new IPAddress(true, ['192.168.0.1'], null, $headersToInspect);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.0.1',


### PR DESCRIPTION
If the Proxy check is enabled (first constructor parameter is true), but the trusted Proxy list is empty (second constructor parameter not specified or empty array), it becomes possible to assign an IP address from an untrusted source.