### PR TITLE
Implement psr-15 middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         }
     ],
     "require": {
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -3,8 +3,10 @@ namespace RKA\Middleware;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
-class IpAddress
+class IpAddress implements MiddlewareInterface
 {
     /**
      * Enable checking of proxy headers (X-Forwarded-For to determined client IP.
@@ -69,6 +71,17 @@ class IpAddress
         if (!empty($headersToInspect)) {
             $this->headersToInspect = $headersToInspect;
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $ipAddress = $this->determineClientIpAddress($request);
+        $request = $request->withAttribute($this->attributeName, $ipAddress);
+
+        return $handler->handle($request);
     }
 
     /**

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -1,6 +1,10 @@
 <?php
 namespace RKA\Middleware\Test;
 
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Server\MiddlewareInterface;
 use RKA\Middleware\IpAddress;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\ServerRequestFactory;
@@ -267,5 +271,27 @@ class RendererTest extends \PHPUnit_Framework_TestCase
         });
 
         $this->assertSame('192.168.1.3', $ipAddress);
+    }
+
+
+    public function testPSR15()
+    {
+        $middleware = new IPAddress();
+        $request = ServerRequestFactory::fromGlobals([
+            'REMOTE_ADDR' => '192.168.0.1',
+        ]);
+
+        $handler = (new class implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $response = new Response();
+                $response->getBody()->write("Hello World");
+
+                return $response;
+            }
+        });
+        $response = $middleware->process($request, $handler);
+
+        $this->assertSame("Hello World", (string) $response->getBody());
     }
 }


### PR DESCRIPTION
Hi,

I have tried to in-corporate psr-15 so that this can be used with expressive 3 or any psr-15 middleware.

I guess this will not be a BC break for nothing is relying or change in API.

If it is I hope we can remove __invoke and push major version.