### PR TITLE
Set minimum PHP version to 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 language: php
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
+  - 7.1
+  - 7.2
 
 before_install:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Client IP address middleware
 
-PSR-7 Middleware that determines the client IP address and stores it as an `ServerRequest` attribute called `ip_address`.
+PSR-15 Middleware that determines the client IP address and stores it as an `ServerRequest` attribute called `ip_address`.
 
 [![Build status][Master image]][Master]
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "akrabat/rka-ip-address-middleware",
-    "description": "PSR-7 Middleware that determines the client IP address and stores it as an ServerRequest attribute",
+    "description": "PSR-15 middleware that determines the client IP address and stores it as a ServerRequest attribute",
     "keywords": [
         "psr7", "middleware", "ip"
     ],
@@ -15,13 +15,14 @@
         }
     ],
     "require": {
+        "php": "^7.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
-        "squizlabs/php_codesniffer": "^2.3",
-        "zendframework/zend-diactoros": "^1.1"
+        "phpunit/phpunit": "^6.5",
+        "squizlabs/php_codesniffer": "^3.2",
+        "zendframework/zend-diactoros": "^1.7"
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0"?>
 <ruleset name="RKA">
     <rule ref="PSR2"/>
-    
+
+    <arg value="p" />
+    <arg name="colors"/>
+
     <!-- Check src and tests directories -->
     <file>src</file>
     <file>tests</file>

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -1,19 +1,20 @@
 <?php
 namespace RKA\Middleware\Test;
 
-use Psr\Http\Message\ServerRequestInterface;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use RKA\Middleware\IpAddress;
+use RuntimeException;
+use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\ServerRequestFactory;
-use Zend\Diactoros\Uri;
-use Zend\Diactoros\Response;
 use Zend\Diactoros\Stream;
-use RuntimeException;
+use Zend\Diactoros\Uri;
 
-class RendererTest extends \PHPUnit_Framework_TestCase
+class RendererTest extends TestCase
 {
     public function testIpSetByRemoteAddr()
     {


### PR DESCRIPTION
PSR-15 requires PHP 7.0+, so this is now the minimum version. Update PHP Unit and PHPCS too.