### PR TITLE
Allow an empty trusted proxies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Note that the proxy headers are only checked if the first parameter to the const
 
 **Trusted Proxies**
 
-You can set a list of proxies that are trusted as the second constructor parameter. If this list is set, then the proxy headers will only be checked if the `REMOTE_ADDR` is in the trusted list.
+If you configure to check the proxy headers (first parameter is `true`), you have to provide an array of trusted proxies as the second parameter. If the array is empty, the proxy headers will always be evaluated. If the array is not empty, it must contain strings with IP addresses, one of them must be the `$_SERVER['REMOTE_ADDR']` variable in order to allow evaluating the proxy headers - otherwise the `REMOTE_ADDR` itself is returned.
 
 **Attribute name**
 
@@ -24,6 +24,12 @@ By default, the name of the attribute is '`ip_address`'. This can be changed by 
 **Headers to inspect**
 
 By default, this middleware checks the 'Forwarded', 'X-Forwarded-For', 'X-Forwarded', 'X-Cluster-Client-Ip' and 'Client-Ip' headers. You can replace this list with your own using the fourth constructor parameter.
+
+## Security considerations
+
+A malicious client may send any header to your proxy, including any proxy headers, containing any IP address. If your proxy simply adds another IP address to the header, an attacker can send a fake IP. Make sure to setup your proxy in a way that removes any sent (and possibly faked) headers from the original request and replaces them with correct values (i.e. the currently used `REMOTE_ADDR` on the proxy server).
+
+This library cannot by design ensure you get correct and trustworthy results if your network environment isn't setup properly.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,6 @@
             "homepage": "http://akrabat.com"
         }
     ],
-    "replace": {
-        "akrabat/rka-ip-address-middleware": "*"
-    },
     "require": {
         "php": "^7.0",
         "psr/http-message": "^1.0",

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -124,10 +124,14 @@ class IpAddress implements MiddlewareInterface
             $ipAddress = $serverParams['REMOTE_ADDR'];
         }
 
-        if ($this->checkProxyHeaders
-            && !empty($this->trustedProxies)
-            && in_array($ipAddress, $this->trustedProxies)
-        ) {
+        $checkProxyHeaders = $this->checkProxyHeaders;
+        if ($checkProxyHeaders && !empty($this->trustedProxies)) {
+            if (!in_array($ipAddress, $this->trustedProxies)) {
+                $checkProxyHeaders = false;
+            }
+        }
+
+        if ($checkProxyHeaders) {
             foreach ($this->headersToInspect as $header) {
                 if ($request->hasHeader($header)) {
                     $ip = $this->getFirstIpAddressFromHeader($request, $header);

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -58,10 +58,14 @@ class IpAddress implements MiddlewareInterface
      */
     public function __construct(
         $checkProxyHeaders = false,
-        array $trustedProxies = [],
+        array $trustedProxies = null,
         $attributeName = null,
         array $headersToInspect = []
     ) {
+        if ($checkProxyHeaders && $trustedProxies === null) {
+            throw new \InvalidArgumentException('Use of the forward headers requires an array for trusted proxies.');
+        }
+
         $this->checkProxyHeaders = $checkProxyHeaders;
         $this->trustedProxies = $trustedProxies;
 

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -53,7 +53,7 @@ class RendererTest extends TestCase
 
     public function testXForwardedForIp()
     {
-        $middleware = new IPAddress(true, ['192.168.1.1']);
+        $middleware = new IPAddress(true);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -93,7 +93,7 @@ class RendererTest extends TestCase
 
     public function testHttpClientIp()
     {
-        $middleware = new IPAddress(true, ['192.168.1.1']);
+        $middleware = new IPAddress(true);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -113,7 +113,7 @@ class RendererTest extends TestCase
 
     public function testXForwardedForIpV6()
     {
-        $middleware = new IPAddress(true, ['192.168.1.1']);
+        $middleware = new IPAddress(true);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -133,7 +133,7 @@ class RendererTest extends TestCase
 
     public function testXForwardedForWithInvalidIp()
     {
-        $middleware = new IPAddress(true, ['192.168.1.1']);
+        $middleware = new IPAddress(true);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -193,7 +193,7 @@ class RendererTest extends TestCase
 
     public function testForwardedWithMultipleFor()
     {
-        $middleware = new IPAddress(true, ['192.168.1.1']);
+        $middleware = new IPAddress(true);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -213,7 +213,7 @@ class RendererTest extends TestCase
 
     public function testForwardedWithAllOptions()
     {
-        $middleware = new IPAddress(true, ['192.168.1.1']);
+        $middleware = new IPAddress(true);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -233,7 +233,7 @@ class RendererTest extends TestCase
 
     public function testForwardedWithWithIpV6()
     {
-        $middleware = new IPAddress(true, ['192.168.1.1']);
+        $middleware = new IPAddress(true);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -256,7 +256,7 @@ class RendererTest extends TestCase
         $headersToInspect = [
             'Foo-Bar'
         ];
-        $middleware = new IPAddress(true, ['192.168.0.1'], null, $headersToInspect);
+        $middleware = new IPAddress(true, [], null, $headersToInspect);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.0.1',

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -53,7 +53,7 @@ class RendererTest extends TestCase
 
     public function testXForwardedForIp()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, []);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -193,7 +193,7 @@ class RendererTest extends TestCase
 
     public function testForwardedWithMultipleFor()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, []);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -213,7 +213,7 @@ class RendererTest extends TestCase
 
     public function testForwardedWithAllOptions()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, []);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -233,7 +233,7 @@ class RendererTest extends TestCase
 
     public function testForwardedWithWithIpV6()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, []);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -93,7 +93,7 @@ class RendererTest extends TestCase
 
     public function testHttpClientIp()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, []);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -113,7 +113,7 @@ class RendererTest extends TestCase
 
     public function testXForwardedForIpV6()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, []);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -133,7 +133,7 @@ class RendererTest extends TestCase
 
     public function testXForwardedForWithInvalidIp()
     {
-        $middleware = new IPAddress(true);
+        $middleware = new IPAddress(true, []);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.1.1',
@@ -294,5 +294,11 @@ class RendererTest extends TestCase
         $response = $middleware->process($request, $handler);
 
         $this->assertSame("Hello World", (string) $response->getBody());
+    }
+
+    public function testNotGivingAProxyListShouldThrowException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new IpAddress(true);
     }
 }


### PR DESCRIPTION
… true), but the trusted Proxy list is empty (second constructor parameter not specified or empty array), it becomes possible to assign an IP address from an untrusted source."

This reverts commit 50fdfc91fde2c92b2a361b4096de21ecbd4154cf.

Fixes #15 