### PR TITLE
Extract the parser into a separate usable class.

### DIFF
--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -8,25 +8,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class IpAddress implements MiddlewareInterface
 {
-    /**
-     * Enable checking of proxy headers (X-Forwarded-For to determined client IP.
-     *
-     * Defaults to false as only $_SERVER['REMOTE_ADDR'] is a trustworthy source
-     * of IP address.
-     *
-     * @var bool
-     */
-    protected $checkProxyHeaders;
-
-    /**
-     * List of trusted proxy IP addresses
-     *
-     * If not empty, then one of these IP addresses must be in $_SERVER['REMOTE_ADDR']
-     * in order for the proxy headers to be looked at.
-     *
-     * @var array
-     */
-    protected $trustedProxies;
 
     /**
      * Name of the attribute added to the ServerRequest object
@@ -36,17 +17,11 @@ class IpAddress implements MiddlewareInterface
     protected $attributeName = 'ip_address';
 
     /**
-     * List of proxy headers inspected for the client IP address
+     * The IP Address Parser
      *
-     * @var array
+     * @var \RKA\Middleware\IpAddressParser
      */
-    protected $headersToInspect = [
-        'Forwarded',
-        'X-Forwarded-For',
-        'X-Forwarded',
-        'X-Cluster-Client-Ip',
-        'Client-Ip',
-    ];
+    protected $parser;
 
     /**
      * Constructor
@@ -62,19 +37,11 @@ class IpAddress implements MiddlewareInterface
         $attributeName = null,
         array $headersToInspect = []
     ) {
-        if ($checkProxyHeaders && $trustedProxies === null) {
-            throw new \InvalidArgumentException('Use of the forward headers requires an array for trusted proxies.');
-        }
-
-        $this->checkProxyHeaders = $checkProxyHeaders;
-        $this->trustedProxies = $trustedProxies;
-
         if ($attributeName) {
             $this->attributeName = $attributeName;
         }
-        if (!empty($headersToInspect)) {
-            $this->headersToInspect = $headersToInspect;
-        }
+
+        $this->parser = new IpAddressParser($checkProxyHeaders, $trustedProxies, $headersToInspect);
     }
 
     /**
@@ -85,7 +52,7 @@ class IpAddress implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $ipAddress = $this->determineClientIpAddress($request);
+        $ipAddress = $this->parser->determineClientIpAddress($request);
         $request = $request->withAttribute($this->attributeName, $ipAddress);
 
         return $handler->handle($request);
@@ -107,109 +74,9 @@ class IpAddress implements MiddlewareInterface
             return $response;
         }
 
-        $ipAddress = $this->determineClientIpAddress($request);
+        $ipAddress = $this->parser->determineClientIpAddress($request);
         $request = $request->withAttribute($this->attributeName, $ipAddress);
 
         return $response = $next($request, $response);
-    }
-
-    /**
-     * Find out the client's IP address from the headers available to us
-     *
-     * @param  ServerRequestInterface $request PSR-7 Request
-     * @return string
-     */
-    protected function determineClientIpAddress($request)
-    {
-        $ipAddress = null;
-
-        $serverParams = $request->getServerParams();
-        if (isset($serverParams['REMOTE_ADDR'])) {
-            $remoteAddr = $this->extractIpAddress($serverParams['REMOTE_ADDR']);
-            if ($this->isValidIpAddress($remoteAddr)) {
-                $ipAddress = $remoteAddr;
-            }
-        }
-
-        $checkProxyHeaders = $this->checkProxyHeaders;
-        if ($checkProxyHeaders && !empty($this->trustedProxies)) {
-            if (!in_array($ipAddress, $this->trustedProxies)) {
-                $checkProxyHeaders = false;
-            }
-        }
-
-        if ($checkProxyHeaders) {
-            foreach ($this->headersToInspect as $header) {
-                if ($request->hasHeader($header)) {
-                    $ip = $this->getFirstIpAddressFromHeader($request, $header);
-                    if ($this->isValidIpAddress($ip)) {
-                        $ipAddress = $ip;
-                        break;
-                    }
-                }
-            }
-        }
-
-        return $ipAddress;
-    }
-
-    /**
-     * Remove port from IPV4 address if it exists
-     *
-     * Note: leaves IPV6 addresses alone
-     *
-     * @param  string $ipAddress
-     * @return string
-     */
-    protected function extractIpAddress($ipAddress)
-    {
-        $parts = explode(':', $ipAddress);
-        if (count($parts) == 2) {
-            if (filter_var($parts[0], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
-                return $parts[0];
-            }
-        }
-
-        return $ipAddress;
-    }
-
-    /**
-     * Check that a given string is a valid IP address
-     *
-     * @param  string  $ip
-     * @return boolean
-     */
-    protected function isValidIpAddress($ip)
-    {
-        $flags = FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6;
-        if (filter_var($ip, FILTER_VALIDATE_IP, $flags) === false) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Find out the client's IP address from the headers available to us
-     *
-     * @param  ServerRequestInterface $request PSR-7 Request
-     * @param  string $header Header name
-     * @return string
-     */
-    private function getFirstIpAddressFromHeader($request, $header)
-    {
-        $items = explode(',', $request->getHeaderLine($header));
-        $headerValue = trim(reset($items));
-
-        if (ucfirst($header) == 'Forwarded') {
-            foreach (explode(';', $headerValue) as $headerPart) {
-                if (strtolower(substr($headerPart, 0, 4)) == 'for=') {
-                    $for = explode(']', $headerPart);
-                    $headerValue = trim(substr(reset($for), 4), " \t\n\r\0\x0B" . "\"[]");
-                    break;
-                }
-            }
-        }
-
-        return $this->extractIpAddress($headerValue);
     }
 }

--- a/src/IpAddressParser.php
+++ b/src/IpAddressParser.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace RKA\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class IpAddressParser
+{
+
+    /**
+     * Enable checking of proxy headers (X-Forwarded-For to determined client IP.
+     *
+     * Defaults to false as only $_SERVER['REMOTE_ADDR'] is a trustworthy source
+     * of IP address.
+     *
+     * @var bool
+     */
+    protected $checkProxyHeaders;
+
+    /**
+     * List of trusted proxy IP addresses
+     *
+     * If not empty, then one of these IP addresses must be in $_SERVER['REMOTE_ADDR']
+     * in order for the proxy headers to be looked at.
+     *
+     * @var array
+     */
+    protected $trustedProxies;
+
+    /**
+     * List of proxy headers inspected for the client IP address
+     *
+     * @var array
+     */
+    protected $headersToInspect = [
+        'Forwarded',
+        'X-Forwarded-For',
+        'X-Forwarded',
+        'X-Cluster-Client-Ip',
+        'Client-Ip',
+    ];
+
+    /**
+     * Constructor
+     *
+     * @param bool $checkProxyHeaders Whether to use proxy headers to determine client IP
+     * @param array $trustedProxies   List of IP addresses of trusted proxies
+     * @param string $attributeName   Name of attribute added to ServerRequest object
+     * @param array $headersToInspect List of headers to inspect
+     */
+    public function __construct(
+        $checkProxyHeaders = false,
+        array $trustedProxies = null,
+        array $headersToInspect = []
+    ) {
+        if ($checkProxyHeaders && $trustedProxies === null) {
+            throw new \InvalidArgumentException('Use of the forward headers requires an array for trusted proxies.');
+        }
+
+        $this->checkProxyHeaders = $checkProxyHeaders;
+        $this->trustedProxies = $trustedProxies;
+
+        if (!empty($headersToInspect)) {
+            $this->headersToInspect = $headersToInspect;
+        }
+    }
+
+
+    /**
+     * Find out the client's IP address from the headers available to us
+     *
+     * @param  ServerRequestInterface $request PSR-7 Request
+     * @return string
+     */
+    public function determineClientIpAddress($request)
+    {
+        $ipAddress = null;
+
+        $serverParams = $request->getServerParams();
+        if (isset($serverParams['REMOTE_ADDR'])) {
+            $remoteAddr = $this->extractIpAddress($serverParams['REMOTE_ADDR']);
+            if ($this->isValidIpAddress($remoteAddr)) {
+                $ipAddress = $remoteAddr;
+            }
+        }
+
+        $checkProxyHeaders = $this->checkProxyHeaders;
+        if ($checkProxyHeaders && !empty($this->trustedProxies)) {
+            if (!in_array($ipAddress, $this->trustedProxies)) {
+                $checkProxyHeaders = false;
+            }
+        }
+
+        if ($checkProxyHeaders) {
+            foreach ($this->headersToInspect as $header) {
+                if ($request->hasHeader($header)) {
+                    $ip = $this->getFirstIpAddressFromHeader($request, $header);
+                    if ($this->isValidIpAddress($ip)) {
+                        $ipAddress = $ip;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return $ipAddress;
+    }
+
+
+    /**
+     * Remove port from IPV4 address if it exists
+     *
+     * Note: leaves IPV6 addresses alone
+     *
+     * @param  string $ipAddress
+     * @return string
+     */
+    protected function extractIpAddress($ipAddress)
+    {
+        $parts = explode(':', $ipAddress);
+        if (count($parts) == 2) {
+            if (filter_var($parts[0], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+                return $parts[0];
+            }
+        }
+
+        return $ipAddress;
+    }
+
+    /**
+     * Check that a given string is a valid IP address
+     *
+     * @param  string  $ip
+     * @return boolean
+     */
+    protected function isValidIpAddress($ip)
+    {
+        $flags = FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6;
+        if (filter_var($ip, FILTER_VALIDATE_IP, $flags) === false) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Find out the client's IP address from the headers available to us
+     *
+     * @param  ServerRequestInterface $request PSR-7 Request
+     * @param  string $header Header name
+     * @return string
+     */
+    private function getFirstIpAddressFromHeader($request, $header)
+    {
+        $items = explode(',', $request->getHeaderLine($header));
+        $headerValue = trim(reset($items));
+
+        if (ucfirst($header) == 'Forwarded') {
+            foreach (explode(';', $headerValue) as $headerPart) {
+                if (strtolower(substr($headerPart, 0, 4)) == 'for=') {
+                    $for = explode(']', $headerPart);
+                    $headerValue = trim(substr(reset($for), 4), " \t\n\r\0\x0B" . "\"[]");
+                    break;
+                }
+            }
+        }
+
+        return $this->extractIpAddress($headerValue);
+    }
+}


### PR DESCRIPTION
Right off the bat, I expect this to be rejected as it does complicate the API surface a bit.

That said however I'd really prefer to see if there is any interest rather than maintaining a fork myself.

Basically, I'd love to be able to use the IP Address parsing portion of this outside the context of a middleware. It's nice functionality and tying it to a specific use case is kind of a shame.

I am of course open to any and all changes on this you might request.