### PR TITLE
Add CIDR matching for trusted proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Note that the proxy headers are only checked if the first parameter to the const
 
 **Trusted Proxies**
 
-If you configure to check the proxy headers (first parameter is `true`), you have to provide an array of trusted proxies as the second parameter. If the array is empty, the proxy headers will always be evaluated. If the array is not empty, it must contain strings with IP addresses, one of them must be the `$_SERVER['REMOTE_ADDR']` variable in order to allow evaluating the proxy headers - otherwise the `REMOTE_ADDR` itself is returned.
+If you configure to check the proxy headers (first parameter is `true`), you have to provide an array of trusted proxies as the second parameter. If the array is empty, the proxy headers will always be evaluated. If the array is not empty, it must contain strings with IP addresses or networks in CIDR-notation. One of them must match the `$_SERVER['REMOTE_ADDR']` variable in order to allow evaluating the proxy headers - otherwise the `REMOTE_ADDR` itself is returned.
 
 **Attribute name**
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "akrabat/ip-address-middleware",
+    "name": "pmous/ip-address-middleware",
     "description": "PSR-15 middleware that determines the client IP address and stores it as a ServerRequest attribute",
     "keywords": [
         "psr7", "middleware", "ip"
@@ -12,9 +12,15 @@
             "name": "Rob Allen",
             "email": "rob@akrabat.com",
             "homepage": "http://akrabat.com"
-        }
-    ],
+        },
+		{
+			"name": "Paul Mourus",
+			"email": "mous@myndr.nl",
+			"homepage": "https://myndr.nl"
+		}
+	],
     "replace": {
+		"akrabat/ip-address-middleware": "*",
         "akrabat/rka-ip-address-middleware": "*"
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
             "email": "rob@akrabat.com",
             "homepage": "http://akrabat.com"
         },
-		{
-			"name": "Paul Mourus",
-			"email": "mous@myndr.nl",
-			"homepage": "https://myndr.nl"
-		}
-	],
+        {
+            "name": "Paul Mourus",
+            "email": "mous@myndr.nl",
+            "homepage": "https://myndr.nl"
+        }
+    ],
     "replace": {
-		"akrabat/ip-address-middleware": "*",
+        "akrabat/ip-address-middleware": "*",
         "akrabat/rka-ip-address-middleware": "*"
     },
     "require": {

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -161,15 +161,21 @@ class IpAddress implements MiddlewareInterface
      */
     private function checkTrustedProxies(string $ipAddress):bool
     {
-        if (empty($this->trustedProxies)) return true;
-        foreach($this->trustedProxies as $i => $proxy) {
+        if (empty($this->trustedProxies)) {
+            return true;
+        }
+        foreach ($this->trustedProxies as $i => $proxy) {
             $parts = explode('/', $proxy);
             switch (count($parts)) {
                 case 1:
-                    if ($proxy === $ipAddress) return true;
+                    if ($proxy === $ipAddress) {
+                        return true;
+                    }
                     break;
                 case 2:
-                    if ($this->addressInNetwork($ipAddress, $parts[0], $parts[1])) return true;
+                    if ($this->addressInNetwork($ipAddress, $parts[0], $parts[1])) {
+                        return true;
+                    }
                     break;
                 default:
                     throw new Exception('Wrong ip address format in trustedProxies on index ' . $i);

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -83,9 +83,9 @@ class IpAddress implements MiddlewareInterface
      *
      * Set the "$attributeName" attribute to the client's IP address as determined from
      * the proxy header (X-Forwarded-For or from $_SERVER['REMOTE_ADDR']
-	 *
-	 * @throws Exception
-	 */
+     *
+     * @throws Exception
+     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $ipAddress = $this->determineClientIpAddress($request);
@@ -103,8 +103,8 @@ class IpAddress implements MiddlewareInterface
      * @param callable $next                  Next middleware
      *
      * @return ResponseInterface
-	 * @throws Exception
-	 */
+     * @throws Exception
+     */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next)
     {
         if (!$next) {
@@ -122,8 +122,8 @@ class IpAddress implements MiddlewareInterface
      *
      * @param  ServerRequestInterface $request PSR-7 Request
      * @return string
-	 * @throws Exception
-	 */
+     * @throws Exception
+     */
     protected function determineClientIpAddress($request)
     {
         $ipAddress = null;
@@ -151,49 +151,49 @@ class IpAddress implements MiddlewareInterface
         return $ipAddress;
     }
 
-	/**
-	 * See if given ipAddress is trusted. Supporting CIDR now.
-	 * If no trustedProxies are given, return true.
-	 *
-	 * @param string $ipAddress
-	 * @return bool
-	 * @throws Exception
-	 */
+    /**
+     * See if given ipAddress is trusted. Supporting CIDR now.
+     * If no trustedProxies are given, return true.
+     *
+     * @param string $ipAddress
+     * @return bool
+     * @throws Exception
+     */
     private function checkTrustedProxies(string $ipAddress):bool
-	{
-		if (empty($this->trustedProxies)) return true;
-		foreach($this->trustedProxies as $i => $proxy) {
-			$parts = explode('/', $proxy);
-			switch (count($parts)) {
-				case 1:
-					if ($proxy === $ipAddress) return true;
-					break;
-				case 2:
-					if ($this->addressInNetwork($ipAddress, $parts[0], $parts[1])) return true;
-					break;
-				default:
-					throw new Exception('Wrong ip address format in trustedProxies on index ' . $i);
-			}
-		}
-		return false;
-	}
+    {
+        if (empty($this->trustedProxies)) return true;
+        foreach($this->trustedProxies as $i => $proxy) {
+            $parts = explode('/', $proxy);
+            switch (count($parts)) {
+                case 1:
+                    if ($proxy === $ipAddress) return true;
+                    break;
+                case 2:
+                    if ($this->addressInNetwork($ipAddress, $parts[0], $parts[1])) return true;
+                    break;
+                default:
+                    throw new Exception('Wrong ip address format in trustedProxies on index ' . $i);
+            }
+        }
+        return false;
+    }
 
-	/**
-	 * @param string $ipAddress
-	 * @param string $network
-	 * @param int $width
-	 * @return bool
-	 */
-	private function addressInNetwork(string $ipAddress, string $network, int $width):bool
-	{
-		// Not really needed, but more efficient...
-		if ($width === 32) {
-			return $network === $ipAddress;
-		}
-		// Do the math for all other cases
-		$mask = ~ ((1 << (32 - $width)) - 1);
-		return (ip2long($ipAddress) & $mask) == (ip2long($network) & $mask);
-	}
+    /**
+     * @param string $ipAddress
+     * @param string $network
+     * @param int $width
+     * @return bool
+     */
+    private function addressInNetwork(string $ipAddress, string $network, int $width):bool
+    {
+        // Not really needed, but more efficient...
+        if ($width === 32) {
+            return $network === $ipAddress;
+        }
+        // Do the math for all other cases
+        $mask = ~ ((1 << (32 - $width)) - 1);
+        return (ip2long($ipAddress) & $mask) == (ip2long($network) & $mask);
+    }
 
     /**
      * Remove port from IPV4 address if it exists

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -224,84 +224,84 @@ class RendererTest extends TestCase
         $this->assertSame('192.168.0.2', $ipAddress);
     }
 
-	/**
-	 * @dataProvider providerTrustedProxyWithCIDR
-	 * @param array $proxies
-	 * @param string $forwardFor
-	 * @param string $ip
-	 * @param string $expect
-	 * @param string $expectedException = ''
-	 * @throws \Exception
-	 */
-	public function testTrustedProxyWithCIDR(array $proxies, string $forwardFor, string $ip, string $expect, string $expectedException = '')
-	{
-		if ($expectedException) {
-			$this->expectException($expectedException);
-		}
+    /**
+     * @dataProvider providerTrustedProxyWithCIDR
+     * @param array $proxies
+     * @param string $forwardFor
+     * @param string $ip
+     * @param string $expect
+     * @param string $expectedException = ''
+     * @throws \Exception
+     */
+    public function testTrustedProxyWithCIDR(array $proxies, string $forwardFor, string $ip, string $expect, string $expectedException = '')
+    {
+        if ($expectedException) {
+            $this->expectException($expectedException);
+        }
 
-		$middleware = new IPAddress(true, $proxies);
+        $middleware = new IPAddress(true, $proxies);
 
-		$request = ServerRequestFactory::fromGlobals(
-			[
-					'REMOTE_ADDR' => $ip,
-					'HTTP_X_FORWARDED_FOR' => $forwardFor
-			]);
-		$response = new Response();
+        $request = ServerRequestFactory::fromGlobals(
+            [
+                    'REMOTE_ADDR' => $ip,
+                    'HTTP_X_FORWARDED_FOR' => $forwardFor
+            ]);
+        $response = new Response();
 
-		$ipAddress = '';
-		$response  = $middleware($request, $response, function ($request, $response) use (&$ipAddress) {
-			// simply store the "ip_address" attribute in to the referenced $ipAddress
-			$ipAddress = $request->getAttribute('ip_address');
-			return $response;
-		});
+        $ipAddress = '';
+        $response  = $middleware($request, $response, function ($request, $response) use (&$ipAddress) {
+            // simply store the "ip_address" attribute in to the referenced $ipAddress
+            $ipAddress = $request->getAttribute('ip_address');
+            return $response;
+        });
 
-		if (!$expectedException) {
-			$this->assertSame($expect, $ipAddress);
-		}
-	}
+        if (!$expectedException) {
+            $this->assertSame($expect, $ipAddress);
+        }
+    }
 
-	public function providerTrustedProxyWithCIDR():array
-	{
-		return [
-			'match-first-proxy-32' => [
-				'proxies' => ['192.168.0.1/32', '192.168.0.2/32'],
-				'forwardFor' => '192.168.1.3',
-				'ip' => '192.168.0.1',
-				'expect' => '192.168.1.3'
-			],
-			'no-match-first-proxy-32' => [
-				'proxies' => ['192.168.0.1/32', '192.168.0.2/32'],
-				'forwardFor' => '192.168.1.3',
-				'ip' => '192.168.0.3',
-				'expect' => '192.168.0.3'
-			],
-			'match-first-proxy-16' => [
-				'proxies' => ['192.168.0.0/16', '10.168.0.2'],
-				'forwardFor' => '192.168.1.3',
-				'ip' => '192.168.255.1',
-				'expect' => '192.168.1.3'
-			],
-			'no-match-first-proxy-16' => [
-				'proxies' => ['192.168.0.0/16', '10.168.0.2'],
-				'forwardFor' => '192.168.1.3',
-				'ip' => '192.169.255.1',
-				'expect' => '192.169.255.1'
-			],
-			'match-second-proxy-8' => [
-				'proxies' => ['192.168.0.0/24', '10.0.0.0/8'],
-				'forwardFor' => '192.168.1.3',
-				'ip' => '10.168.255.1',
-				'expect' => '192.168.1.3'
-			],
-			'exception-wrong-format' => [
-				'proxies' => ['192.168.0.0/24/8'],
-				'forwardFor' => '192.168.1.3',
-				'ip' => '10.168.255.1',
-				'expect' => '',
-				'expectedException' => \Exception::class
-			],
-		];
-	}
+    public function providerTrustedProxyWithCIDR():array
+    {
+        return [
+            'match-first-proxy-32' => [
+                'proxies' => ['192.168.0.1/32', '192.168.0.2/32'],
+                'forwardFor' => '192.168.1.3',
+                'ip' => '192.168.0.1',
+                'expect' => '192.168.1.3'
+            ],
+            'no-match-first-proxy-32' => [
+                'proxies' => ['192.168.0.1/32', '192.168.0.2/32'],
+                'forwardFor' => '192.168.1.3',
+                'ip' => '192.168.0.3',
+                'expect' => '192.168.0.3'
+            ],
+            'match-first-proxy-16' => [
+                'proxies' => ['192.168.0.0/16', '10.168.0.2'],
+                'forwardFor' => '192.168.1.3',
+                'ip' => '192.168.255.1',
+                'expect' => '192.168.1.3'
+            ],
+            'no-match-first-proxy-16' => [
+                'proxies' => ['192.168.0.0/16', '10.168.0.2'],
+                'forwardFor' => '192.168.1.3',
+                'ip' => '192.169.255.1',
+                'expect' => '192.169.255.1'
+            ],
+            'match-second-proxy-8' => [
+                'proxies' => ['192.168.0.0/24', '10.0.0.0/8'],
+                'forwardFor' => '192.168.1.3',
+                'ip' => '10.168.255.1',
+                'expect' => '192.168.1.3'
+            ],
+            'exception-wrong-format' => [
+                'proxies' => ['192.168.0.0/24/8'],
+                'forwardFor' => '192.168.1.3',
+                'ip' => '10.168.255.1',
+                'expect' => '',
+                'expectedException' => \Exception::class
+            ],
+        ];
+    }
     public function testForwardedWithMultipleFor()
     {
         $middleware = new IPAddress(true, []);

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -233,8 +233,13 @@ class RendererTest extends TestCase
      * @param string $expectedException = ''
      * @throws \Exception
      */
-    public function testTrustedProxyWithCIDR(array $proxies, string $forwardFor, string $ip, string $expect, string $expectedException = '')
-    {
+    public function testTrustedProxyWithCIDR(
+        array $proxies,
+        string $forwardFor,
+        string $ip,
+        string $expect,
+        string $expectedException = ''
+    ) {
         if ($expectedException) {
             $this->expectException($expectedException);
         }
@@ -243,9 +248,10 @@ class RendererTest extends TestCase
 
         $request = ServerRequestFactory::fromGlobals(
             [
-                    'REMOTE_ADDR' => $ip,
-                    'HTTP_X_FORWARDED_FOR' => $forwardFor
-            ]);
+                'REMOTE_ADDR' => $ip,
+                'HTTP_X_FORWARDED_FOR' => $forwardFor
+            ]
+        );
         $response = new Response();
 
         $ipAddress = '';


### PR DESCRIPTION
I fixed this issue, then I saw that homeyjd also did a pull request for similar functionality. However, I think my code is cleaner, has a smaller changeset. I only did the cidr, but I really don't think you need the wildcard anyway. For the check, if there is no /, it simply falls back to a compare, so not much change in performance. For /32, same thing. Only for other masks, I do some bit-shifting and stuff. 
Also provided a test, and changed the readme a little. The json file is altered to be able to use it myself. You may ignore that.

Hope you will accept this code, then I can pull this repo again :-)