### PR TITLE
Add CIDR and wildcard matching (rebased version of #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Note that the proxy headers are only checked if the first parameter to the const
 
 **Trusted Proxies**
 
-If you configure to check the proxy headers (first parameter is `true`), you have to provide an array of trusted proxies as the second parameter. If the array is empty, the proxy headers will always be evaluated. If the array is not empty, it must contain strings with IP addresses, one of them must be the `$_SERVER['REMOTE_ADDR']` variable in order to allow evaluating the proxy headers - otherwise the `REMOTE_ADDR` itself is returned.
+If you configure to check the proxy headers (first parameter is `true`), you have to provide an array of trusted proxies as the second parameter. If the array is empty, the proxy headers will always be evaluated. If the array is not empty, it must contain strings with IP addresses or networks in CIDR-notation. One of them must match the `$_SERVER['REMOTE_ADDR']` variable in order to allow evaluating the proxy headers - otherwise the `REMOTE_ADDR` itself is returned.
 
 **Attribute name**
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Note that the proxy headers are only checked if the first parameter to the const
 
 **Trusted Proxies**
 
-If you configure to check the proxy headers (first parameter is `true`), you have to provide an array of trusted proxies as the second parameter. If the array is empty, the proxy headers will always be evaluated. If the array is not empty, it must contain strings with IP addresses or networks in CIDR-notation. One of them must match the `$_SERVER['REMOTE_ADDR']` variable in order to allow evaluating the proxy headers - otherwise the `REMOTE_ADDR` itself is returned.
+If you configure to check the proxy headers (first parameter is `true`), you have to provide an array of trusted proxies as the second parameter. When the array is empty, the proxy headers will always be evaluated which is not recommended. If the array is not empty, it must contain strings with IP addresses (wildcard `*` is allowed in any given part) or networks in CIDR-notation. One of them must match the `$_SERVER['REMOTE_ADDR']` variable in order to allow evaluating the proxy headers - otherwise the `REMOTE_ADDR` itself is returned.
 
 **Attribute name**
 

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -29,6 +29,20 @@ class IpAddress implements MiddlewareInterface
     protected $trustedProxies;
 
     /**
+     * List of trusted proxy IP wildcard ranges
+     *
+     * @var array
+     */
+    protected $trustedWildcard;
+
+    /**
+     * List of trusted proxy IP CIDR ranges
+     *
+     * @var array
+     */
+    protected $trustedCidr;
+
+    /**
      * Name of the attribute added to the ServerRequest object
      *
      * @var string
@@ -67,7 +81,34 @@ class IpAddress implements MiddlewareInterface
         }
 
         $this->checkProxyHeaders = $checkProxyHeaders;
-        $this->trustedProxies = $trustedProxies;
+
+        if ($trustedProxies) {
+            foreach ($trustedProxies as $proxy) {
+                if (strpos($proxy, '*') !== false) {
+                    // Wildcard IP address
+                    // IPv6 is 8 parts separated by ':'
+                    if (strpos($proxy, '.') > 0) {
+                        $delim = '.';
+                        $parts = 4;
+                    } else {
+                        $delim = ':';
+                        $parts = 8;
+                    }
+                    $this->trustedWildcard[] = explode($delim, $proxy, $parts);
+                } elseif (strpos($proxy, '/') > 6) {
+                    // CIDR notation
+                    list($subnet, $bits) = explode('/', $proxy, 2);
+                    $subnet = ip2long($subnet);
+                    $mask = -1 << (32 - $bits);
+                    $min = $subnet & $mask;
+                    $max = $subnet | ~$mask;
+                    $this->trustedCidr[] = [$min, $max];
+                } else {
+                    // String-match IP address
+                    $this->trustedProxies[] = $proxy;
+                }
+            }
+        }
 
         if ($attributeName) {
             $this->attributeName = $attributeName;
@@ -132,9 +173,52 @@ class IpAddress implements MiddlewareInterface
         }
 
         $checkProxyHeaders = $this->checkProxyHeaders;
-        if ($checkProxyHeaders && !empty($this->trustedProxies)) {
-            if (!in_array($ipAddress, $this->trustedProxies)) {
+        if ($checkProxyHeaders) {
+            // Exact Match
+            if ($this->trustedProxies && !in_array($ipAddress, $this->trustedProxies)) {
                 $checkProxyHeaders = false;
+            }
+
+            // Wildcard Match
+            if ($checkProxyHeaders && $this->trustedWildcard) {
+                $checkProxyHeaders = false;
+                // IPv4 has 4 parts separated by '.'
+                // IPv6 has 8 parts separated by ':'
+                if (strpos($ipAddress, '.') > 0) {
+                    $delim = '.';
+                    $parts = 4;
+                } else {
+                    $delim = ':';
+                    $parts = 8;
+                }
+                $ipAddrParts = explode($delim, $ipAddress, $parts);
+                foreach ($this->trustedWildcard as $proxy) {
+                    if (count($proxy) !== $parts) {
+                        continue; // IP version does not match
+                    }
+                    foreach ($proxy as $i => $part) {
+                        if ($part !== '*' && $part !== $ipAddrParts[$i]) {
+                            break 2;// IP does not match, move to next proxy
+                        }
+                    }
+                    $checkProxyHeaders = true;
+                    break;
+                }
+            }
+
+            // CIDR Match
+            if ($checkProxyHeaders && $this->trustedCidr) {
+                $checkProxyHeaders = false;
+                // Only IPv4 is supported for CIDR matching
+                $ipAsLong = ip2long($ipAddress);
+                if ($ipAsLong) {
+                    foreach ($this->trustedCidr as $proxy) {
+                        if ($proxy[0] <= $ipAsLong && $ipAsLong <= $proxy[1]) {
+                            $checkProxyHeaders = true;
+                            break;
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This is a rebased version of #21:

> Only activated if trusted proxy value contains a "*" (wildcard) or "/" (CIDR). 
> Uses strpos() on object-creation, so very low performance hit.
> Tests are included.
>
> I need CIDR matching for using this library within a load-balanced AWS VPC. There is no way to accurately predict the IP addresses for the load balancer nodes, you only know the IP range via CIDR block.