### PR TITLE
Add .gitattributes to clean up release zip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+*.php text eol=lf
+/.gitattributes export-ignore
+/.github/ export-ignore
+/.gitignore export-ignore
+/composer.lock export-ignore
+/phpcs.xml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/tests/ export-ignore


### PR DESCRIPTION
Various artifacts such as tests and build config are not needed in the release zip file. This removes them.

Fixes #23.