### PR TITLE
Support PHP 8.1

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,9 +12,6 @@ jobs:
 
     strategy:
       matrix:
-        dependencies:
-          - "lowest"
-          - "highest"
         php-version:
           - "7.2"
           - "7.3"
@@ -44,15 +41,10 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
-          restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
-
-      - name: "Install lowest dependencies"
-        if: ${{ matrix.dependencies == 'lowest' }}
-        run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest"
+          key: "php-${{ matrix.php-version }}"
+          restore-keys: "php-${{ matrix.php-version }}"
 
       - name: "Install highest dependencies"
-        if: ${{ matrix.dependencies == 'highest' }}
         run: "composer update --no-interaction --no-progress --no-suggest"
 
       - name: "Tests"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,6 +20,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         operating-system:
           - "ubuntu-latest"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 vendor
 composer.lock
+.phpunit.result.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.7/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="true"
@@ -20,9 +20,9 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -162,7 +162,7 @@ class IpAddress implements MiddlewareInterface
      */
     protected function determineClientIpAddress($request)
     {
-        $ipAddress = null;
+        $ipAddress = '';
 
         $serverParams = $request->getServerParams();
         if (isset($serverParams['REMOTE_ADDR'])) {
@@ -232,6 +232,10 @@ class IpAddress implements MiddlewareInterface
                     }
                 }
             }
+        }
+
+        if (empty($ipAddress)) {
+            $ipAddress = null;
         }
 
         return $ipAddress;

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -128,6 +128,17 @@ class RendererTest extends TestCase
         $this->assertNull($ipAddress);
     }
 
+    public function testIpIsNullIfMissingAndProxiesAreConfigured()
+    {
+        error_reporting(-1);
+        $middleware = new IPAddress(true, ['*'], 'IP');
+        $env = [];
+        $ipAddress = $this->simpleRequest($middleware, $env, 'IP');
+
+        $this->assertSame(null, $ipAddress);
+    }
+
+
     public function testXForwardedForIp()
     {
         $middleware = new IPAddress(true, []);


### PR DESCRIPTION
PHP 8.1 gets upset if null is passed to functions like `strpos`, so we now use an empty string. In order to avoid a BC break, we convert it to a null before returning.