### PR TITLE
Specify types for the constructor parameters

### DIFF
--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -202,7 +202,7 @@ class IpAddress implements MiddlewareInterface
                     foreach ($proxy as $i => $part) {
                         if ($part !== '*' && $part !== $ipAddrParts[$i]) {
                             $match = false;
-                            break;// IP does not match, move to next proxy
+                            break; // IP does not match, move to next proxy
                         }
                     }
                     if ($match) {

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -72,7 +72,7 @@ class IpAddress implements MiddlewareInterface
      */
     public function __construct(
         bool $checkProxyHeaders = false,
-        array $trustedProxies = null,
+        array $trustedProxies = [],
         string $attributeName = '',
         array $headersToInspect = []
     ) {

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -106,11 +106,19 @@ class IpAddress implements MiddlewareInterface
             }
         }
 
+        $this->initAttributeName($attributeName);
+        $this->initHeadersToInspect($headersToInspect);
+    }
+
+    /**
+     * @param string $attributeName
+     * @return void
+     */
+    private function initAttributeName(string $attributeName): void
+    {
         if (!empty($attributeName)) {
             $this->attributeName = $attributeName;
         }
-
-        $this->initHeadersToInspect($headersToInspect);
     }
 
     /**

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -73,7 +73,7 @@ class IpAddress implements MiddlewareInterface
     public function __construct(
         bool $checkProxyHeaders = false,
         array $trustedProxies = null,
-        $attributeName = null,
+        string $attributeName = '',
         array $headersToInspect = []
     ) {
         if ($checkProxyHeaders && $trustedProxies === null) {
@@ -110,7 +110,7 @@ class IpAddress implements MiddlewareInterface
             }
         }
 
-        if ($attributeName) {
+        if (!empty($attributeName)) {
             $this->attributeName = $attributeName;
         }
 

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -71,7 +71,7 @@ class IpAddress implements MiddlewareInterface
      * @param array $headersToInspect List of headers to inspect
      */
     public function __construct(
-        $checkProxyHeaders = false,
+        bool $checkProxyHeaders = false,
         array $trustedProxies = null,
         $attributeName = null,
         array $headersToInspect = []

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -69,6 +69,7 @@ class IpAddress implements MiddlewareInterface
      * @param array $trustedProxies   List of IP addresses of trusted proxies
      * @param string $attributeName   Name of attribute added to ServerRequest object
      * @param array $headersToInspect List of headers to inspect
+     * @throws \InvalidArgumentException
      */
     public function __construct(
         bool $checkProxyHeaders = false,

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -69,7 +69,6 @@ class IpAddress implements MiddlewareInterface
      * @param array $trustedProxies   List of IP addresses of trusted proxies
      * @param string $attributeName   Name of attribute added to ServerRequest object
      * @param array $headersToInspect List of headers to inspect
-     * @throws \InvalidArgumentException
      */
     public function __construct(
         bool $checkProxyHeaders = false,
@@ -77,10 +76,6 @@ class IpAddress implements MiddlewareInterface
         string $attributeName = '',
         array $headersToInspect = []
     ) {
-        if ($checkProxyHeaders && $trustedProxies === null) {
-            throw new \InvalidArgumentException('Use of the forward headers requires an array for trusted proxies.');
-        }
-
         $this->checkProxyHeaders = $checkProxyHeaders;
 
         if ($trustedProxies) {

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -110,6 +110,15 @@ class IpAddress implements MiddlewareInterface
             $this->attributeName = $attributeName;
         }
 
+        $this->initHeadersToInspect($headersToInspect);
+    }
+
+    /**
+     * @param array $headersToInspect
+     * @return void
+     */
+    private function initHeadersToInspect(array $headersToInspect): void
+    {
         if (!empty($headersToInspect)) {
             $this->headersToInspect = $headersToInspect;
         }

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -116,10 +116,6 @@ class IpAddress implements MiddlewareInterface
         }
     }
 
-        $this->initAttributeName($attributeName);
-        $this->initHeadersToInspect($headersToInspect);
-    }
-
     /**
      * @param string $attributeName
      * @return void

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -113,6 +113,7 @@ class IpAddress implements MiddlewareInterface
         if ($attributeName) {
             $this->attributeName = $attributeName;
         }
+
         if (!empty($headersToInspect)) {
             $this->headersToInspect = $headersToInspect;
         }
@@ -190,6 +191,7 @@ class IpAddress implements MiddlewareInterface
                     $delim = ':';
                     $parts = 8;
                 }
+
                 $ipAddrParts = explode($delim, $ipAddress, $parts);
                 foreach ($this->trustedWildcard as $proxy) {
                     if (count($proxy) !== $parts) {
@@ -279,6 +281,7 @@ class IpAddress implements MiddlewareInterface
         if (filter_var($ip, FILTER_VALIDATE_IP, $flags) === false) {
             return false;
         }
+
         return true;
     }
 

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -78,33 +78,43 @@ class IpAddress implements MiddlewareInterface
     ) {
         $this->checkProxyHeaders = $checkProxyHeaders;
 
-        if ($trustedProxies) {
-            foreach ($trustedProxies as $proxy) {
-                if (strpos($proxy, '*') !== false) {
-                    // Wildcard IP address
-                    // IPv6 is 8 parts separated by ':'
-                    if (strpos($proxy, '.') > 0) {
-                        $delim = '.';
-                        $parts = 4;
-                    } else {
-                        $delim = ':';
-                        $parts = 8;
-                    }
-                    $this->trustedWildcard[] = explode($delim, $proxy, $parts);
-                } elseif (strpos($proxy, '/') > 6) {
-                    // CIDR notation
-                    list($subnet, $bits) = explode('/', $proxy, 2);
-                    $subnet = ip2long($subnet);
-                    $mask = -1 << (32 - $bits);
-                    $min = $subnet & $mask;
-                    $max = $subnet | ~$mask;
-                    $this->trustedCidr[] = [$min, $max];
+        $this->initTrustedProxies($trustedProxies);
+        $this->initAttributeName($attributeName);
+        $this->initHeadersToInspect($headersToInspect);
+    }
+
+    /**
+     * @param array $trustedProxies
+     * @return void
+     */
+    private function initTrustedProxies(array $trustedProxies): void
+    {
+        foreach ($trustedProxies as $proxy) {
+            if (strpos($proxy, '*') !== false) {
+                // Wildcard IP address
+                // IPv6 is 8 parts separated by ':'
+                if (strpos($proxy, '.') > 0) {
+                    $delim = '.';
+                    $parts = 4;
                 } else {
-                    // String-match IP address
-                    $this->trustedProxies[] = $proxy;
+                    $delim = ':';
+                    $parts = 8;
                 }
+                $this->trustedWildcard[] = explode($delim, $proxy, $parts);
+            } elseif (strpos($proxy, '/') > 6) {
+                // CIDR notation
+                list($subnet, $bits) = explode('/', $proxy, 2);
+                $subnet = ip2long($subnet);
+                $mask = -1 << (32 - $bits);
+                $min = $subnet & $mask;
+                $max = $subnet | ~$mask;
+                $this->trustedCidr[] = [$min, $max];
+            } else {
+                // String-match IP address
+                $this->trustedProxies[] = $proxy;
             }
         }
+    }
 
         $this->initAttributeName($attributeName);
         $this->initHeadersToInspect($headersToInspect);

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -186,6 +186,18 @@ class RendererTest extends TestCase
         $this->assertSame('192.168.1.3', $ipAddress);
     }
 
+    public function testXForwardedForIpV4()
+    {
+        $middleware = new IPAddress(true, []);
+        $env = [
+            'REMOTE_ADDR' => '123.4.5.6',
+            'HTTP_X_FORWARDED_FOR' => '192.168.1.1'
+        ];
+        $ipAddress = $this->simpleRequest($middleware, $env);
+
+        $this->assertSame('192.168.1.1', $ipAddress);
+    }
+
     public function testXForwardedForIpV6()
     {
         $middleware = new IPAddress(true, []);

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -138,7 +138,6 @@ class RendererTest extends TestCase
         $this->assertSame(null, $ipAddress);
     }
 
-
     public function testXForwardedForIp()
     {
         $middleware = new IPAddress(true, []);

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -361,10 +361,4 @@ class RendererTest extends TestCase
         $ipAddress = $this->simpleRequest($middleware, $env);
         $this->assertSame('123.4.5.6', $ipAddress, "Testing proxies: " . implode(', ', $matches));
     }
-
-    public function testNotGivingAProxyListShouldThrowException()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        new IpAddress(true);
-    }
 }

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -276,7 +276,7 @@ class RendererTest extends TestCase
         $headersToInspect = [
             'Foo-Bar'
         ];
-        $middleware = new IPAddress(true, [], null, $headersToInspect);
+        $middleware = new IPAddress(true, [], '', $headersToInspect);
 
         $request = ServerRequestFactory::fromGlobals([
             'REMOTE_ADDR' => '192.168.0.1',

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -162,7 +162,7 @@ class RendererTest extends TestCase
         $this->assertSame('192.168.1.3', $ipAddress);
     }
 
-    public function testProxyIpIsIgnored()
+    public function testProxyIpIsIgnoredWhenNoTrustedProxiesSet()
     {
         $middleware = new IPAddress();
         $env = [

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -140,7 +140,7 @@ class RendererTest extends TestCase
 
     public function testXForwardedForIp()
     {
-        $middleware = new IPAddress(true, []);
+        $middleware = new IPAddress(true, ['192.168.1.*']);
         $env = [
             'REMOTE_ADDR' => '192.168.1.1',
             'HTTP_X_FORWARDED_FOR' => '192.168.1.3, 192.168.1.2, 192.168.1.1'
@@ -152,7 +152,7 @@ class RendererTest extends TestCase
 
     public function testXForwardedForIpWithPort()
     {
-        $middleware = new IPAddress(true, ['192.168.1.1']);
+        $middleware = new IPAddress(true, ['192.168.1.*']);
         $env = [
             'REMOTE_ADDR' => '192.168.1.1:81',
             'HTTP_X_FORWARDED_FOR' => '192.168.1.3:81, 192.168.1.2:81, 192.168.1.1:81'


### PR DESCRIPTION
Hello again,

Another proposition is to specify types for all the constructor parameters. However, there is a little problem with the `$attributeName` parameter which is `null` by default (but it is considered to be of the `string` type according to the docblock information). So, specifying its type will result in a breaking change. In my opinion, it is worth doing because it will lead to a more consistent and cleaner parameters list.