### PR TITLE
Code-readability improvements

### DIFF
--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -201,7 +201,7 @@ class IpAddress implements MiddlewareInterface
                     foreach ($proxy as $i => $part) {
                         if ($part !== '*' && $part !== $ipAddrParts[$i]) {
                             $match = false;
-                            break;// IP does not match, move to next proxy
+                            break; // IP does not match, move to next proxy
                         }
                     }
                     if ($match) {

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -33,7 +33,7 @@ class IpAddress implements MiddlewareInterface
      *
      * @var array
      */
-    protected $trustedWildcard;
+    protected $trustedWildcards;
 
     /**
      * List of trusted proxy IP CIDR ranges
@@ -94,7 +94,7 @@ class IpAddress implements MiddlewareInterface
                         $delim = ':';
                         $parts = 8;
                     }
-                    $this->trustedWildcard[] = explode($delim, $proxy, $parts);
+                    $this->trustedWildcards[] = explode($delim, $proxy, $parts);
                 } elseif (strpos($proxy, '/') > 6) {
                     // CIDR notation
                     list($subnet, $bits) = explode('/', $proxy, 2);
@@ -181,7 +181,7 @@ class IpAddress implements MiddlewareInterface
             }
 
             // Wildcard Match
-            if ($this->checkProxyHeaders && $this->trustedWildcard) {
+            if ($this->checkProxyHeaders && $this->trustedWildcards) {
                 // IPv4 has 4 parts separated by '.'
                 // IPv6 has 8 parts separated by ':'
                 if (strpos($ipAddress, '.') > 0) {
@@ -193,7 +193,7 @@ class IpAddress implements MiddlewareInterface
                 }
 
                 $ipAddrParts = explode($delim, $ipAddress, $parts);
-                foreach ($this->trustedWildcard as $proxy) {
+                foreach ($this->trustedWildcards as $proxy) {
                     if (count($proxy) !== $parts) {
                         continue; // IP version does not match
                     }
@@ -225,7 +225,7 @@ class IpAddress implements MiddlewareInterface
                 }
             }
 
-            if (!$this->trustedProxies && !$this->trustedWildcard && !$this->trustedCidr) {
+            if (!$this->trustedProxies && !$this->trustedWildcards && !$this->trustedCidr) {
                 $checkProxyHeaders = true;
             }
 

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -40,7 +40,7 @@ class IpAddress implements MiddlewareInterface
      *
      * @var array
      */
-    protected $trustedCidr;
+    protected $trustedCidrs;
 
     /**
      * Name of the attribute added to the ServerRequest object
@@ -102,7 +102,7 @@ class IpAddress implements MiddlewareInterface
                     $mask = -1 << (32 - $bits);
                     $min = $subnet & $mask;
                     $max = $subnet | ~$mask;
-                    $this->trustedCidr[] = [$min, $max];
+                    $this->trustedCidrs[] = [$min, $max];
                 } else {
                     // String-match IP address
                     $this->trustedProxies[] = $proxy;
@@ -212,11 +212,11 @@ class IpAddress implements MiddlewareInterface
             }
 
             // CIDR Match
-            if ($this->checkProxyHeaders && $this->trustedCidr) {
+            if ($this->checkProxyHeaders && $this->trustedCidrs) {
                 // Only IPv4 is supported for CIDR matching
                 $ipAsLong = ip2long($ipAddress);
                 if ($ipAsLong) {
-                    foreach ($this->trustedCidr as $proxy) {
+                    foreach ($this->trustedCidrs as $proxy) {
                         if ($proxy[0] <= $ipAsLong && $ipAsLong <= $proxy[1]) {
                             $checkProxyHeaders = true;
                             break;
@@ -225,7 +225,7 @@ class IpAddress implements MiddlewareInterface
                 }
             }
 
-            if (!$this->trustedProxies && !$this->trustedWildcards && !$this->trustedCidr) {
+            if (!$this->trustedProxies && !$this->trustedWildcards && !$this->trustedCidrs) {
                 $checkProxyHeaders = true;
             }
 

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -113,6 +113,7 @@ class IpAddress implements MiddlewareInterface
         if ($attributeName) {
             $this->attributeName = $attributeName;
         }
+
         if (!empty($headersToInspect)) {
             $this->headersToInspect = $headersToInspect;
         }
@@ -190,6 +191,7 @@ class IpAddress implements MiddlewareInterface
                     $delim = ':';
                     $parts = 8;
                 }
+
                 $ipAddrParts = explode($delim, $ipAddress, $parts);
                 foreach ($this->trustedWildcard as $proxy) {
                     if (count($proxy) !== $parts) {
@@ -279,6 +281,7 @@ class IpAddress implements MiddlewareInterface
         if (filter_var($ip, FILTER_VALIDATE_IP, $flags) === false) {
             return false;
         }
+
         return true;
     }
 

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -86,15 +86,7 @@ class IpAddress implements MiddlewareInterface
             foreach ($trustedProxies as $proxy) {
                 if (strpos($proxy, '*') !== false) {
                     // Wildcard IP address
-                    // IPv6 is 8 parts separated by ':'
-                    if (strpos($proxy, '.') > 0) {
-                        $delim = '.';
-                        $parts = 4;
-                    } else {
-                        $delim = ':';
-                        $parts = 8;
-                    }
-                    $this->trustedWildcards[] = explode($delim, $proxy, $parts);
+                    $this->trustedWildcards[] = $this->parseWildcard($proxy);
                 } elseif (strpos($proxy, '/') > 6) {
                     // CIDR notation
                     list($subnet, $bits) = explode('/', $proxy, 2);
@@ -117,6 +109,25 @@ class IpAddress implements MiddlewareInterface
         if (!empty($headersToInspect)) {
             $this->headersToInspect = $headersToInspect;
         }
+    }
+
+    /**
+     * @param string $ipAddress
+     * @return array
+     */
+    private function parseWildcard(string $ipAddress)
+    {
+        // IPv4 has 4 parts separated by '.'
+        // IPv6 has 8 parts separated by ':'
+        if (strpos($ipAddress, '.') > 0) {
+            $delim = '.';
+            $parts = 4;
+        } else {
+            $delim = ':';
+            $parts = 8;
+        }
+
+        return explode($delim, $ipAddress, $parts);
     }
 
     /**

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -89,12 +89,7 @@ class IpAddress implements MiddlewareInterface
                     $this->trustedWildcards[] = $this->parseWildcard($proxy);
                 } elseif (strpos($proxy, '/') > 6) {
                     // CIDR notation
-                    list($subnet, $bits) = explode('/', $proxy, 2);
-                    $subnet = ip2long($subnet);
-                    $mask = -1 << (32 - $bits);
-                    $min = $subnet & $mask;
-                    $max = $subnet | ~$mask;
-                    $this->trustedCidrs[] = [$min, $max];
+                    $this->trustedCidrs[] = $this->parseCidr($proxy);
                 } else {
                     // String-match IP address
                     $this->trustedProxies[] = $proxy;
@@ -128,6 +123,21 @@ class IpAddress implements MiddlewareInterface
         }
 
         return explode($delim, $ipAddress, $parts);
+    }
+
+    /**
+     * @param string $ipAddress
+     * @return array
+     */
+    private function parseCidr(string $ipAddress)
+    {
+        list($subnet, $bits) = explode('/', $ipAddress, 2);
+        $subnet = ip2long($subnet);
+        $mask = -1 << (32 - $bits);
+        $min = $subnet & $mask;
+        $max = $subnet | ~$mask;
+
+        return [$min, $max];
     }
 
     /**

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -162,7 +162,7 @@ class IpAddressTest extends TestCase
         $this->assertSame('192.168.1.3', $ipAddress);
     }
 
-    public function testProxyIpIsIgnored()
+    public function testProxyIpIsIgnoredWhenNoArgumentsProvided()
     {
         $middleware = new IPAddress();
         $env = [

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -293,7 +293,6 @@ class IpAddressTest extends TestCase
         $this->assertSame('192.168.1.3', $ipAddress);
     }
 
-
     public function testPSR15()
     {
         $middleware = new IPAddress();

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -138,7 +138,6 @@ class IpAddressTest extends TestCase
         $this->assertSame(null, $ipAddress);
     }
 
-
     public function testXForwardedForIp()
     {
         $middleware = new IPAddress(true, []);


### PR DESCRIPTION
Hello again,

My proposition with some little improvements:
- rename trustedWildcard to trustedWildcards because it can handle more than one wildcard
- rename trustedCidr to trustedCidrs because it can handle more than one cidr
- extract a process of parsing an address with a wildcard from the constructor to a separate method
- extract a process of parsing an address with cidr from the constructor to a separate method
- rename one of the tests because its former name is a little bit vague and one needs to read code to understand why proxy is ignored
- some style improvements (redundant new line, missed space)