### PR TITLE
Update the run unit tests github action and add PHP 8.3 support

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
           tools: composer:v2, cs2pr
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.composer/cache

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,11 +7,11 @@ on:
 jobs:
   tests:
     name: Tests PHP ${{ matrix.php }}
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ubuntu-latest]
+        os: [ubuntu-latest]
         php-version: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
 
     steps:
       - name: Checkout

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,30 +23,30 @@ jobs:
           - "ubuntu-latest"
 
     steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v2"
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
         with:
-          coverage: "pcov"
-          php-version: "${{ matrix.php-version }}"
+          coverage: pcov
+          php-version: ${{ matrix.php-version }}
           ini-values: memory_limit=-1
           tools: composer:v2, cs2pr
 
-      - name: "Cache dependencies"
-        uses: "actions/cache@v2"
+      - name: Cache dependencies
+        uses: actions/cache@v2
         with:
           path: |
             ~/.composer/cache
             vendor
-          key: "php-${{ matrix.php-version }}"
-          restore-keys: "php-${{ matrix.php-version }}"
+          key: php-${{ matrix.php-version }}
+          restore-keys: php-${{ matrix.php-version }}
 
-      - name: "Install highest dependencies"
-        run: "composer update --no-interaction --no-progress --no-suggest"
+      - name: Install highest dependencies
+        run: composer update --no-interaction --no-progress --no-suggest
 
-      - name: "Tests"
-        run: "vendor/bin/phpunit"
+      - name: Tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
 
     strategy:
+      fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
         php-version: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,11 +1,11 @@
-name: PHPUnit tests
+name: Tests
 
 on:
   pull_request:
   push:
 
 jobs:
-  phpunit:
+  tests:
     name: PHPUnit tests
 
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: "PHPUnit tests"
+name: PHPUnit tests
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   phpunit:
-    name: "PHPUnit tests"
+    name: PHPUnit tests
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   tests:
-    name: PHPUnit tests
+    name: Tests PHP ${{ matrix.php }}
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,15 +12,8 @@ jobs:
 
     strategy:
       matrix:
-        php-version:
-          - "7.2"
-          - "7.3"
-          - "7.4"
-          - "8.0"
-          - "8.1"
-          - "8.2"
-        operating-system:
-          - "ubuntu-latest"
+        operating-system: [ubuntu-latest]
+        php-version: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
 
     steps:
       - name: Checkout

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,9 +7,7 @@ on:
 jobs:
   tests:
     name: Tests PHP ${{ matrix.php }}
-
     runs-on: ${{ matrix.operating-system }}
-
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php-version: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
 
     steps:
       - name: Checkout
@@ -24,7 +24,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: pcov
-          php-version: ${{ matrix.php-version }}
+          php-version: ${{ matrix.php }}
           ini-values: memory_limit=-1
           tools: composer:v2, cs2pr
 
@@ -34,8 +34,8 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: php-${{ matrix.php-version }}
-          restore-keys: php-${{ matrix.php-version }}
+          key: php-${{ matrix.php }}
+          restore-keys: php-${{ matrix.php }}
 
       - name: Install highest dependencies
         run: composer update --no-interaction --no-progress --no-suggest


### PR DESCRIPTION
Hello again,

This PR updates the run unit tests github action and adds support of the PHP 8.3 version.

P.S. to make this file even more consistent with [other projects](https://github.com/slimphp/Slim/blob/4.x/.github/workflows/tests.yml) it could be renamed to `tests.yml`.