### PR TITLE
Mezzio installation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ This library cannot by design ensure you get correct and trustworthy results if 
 
 `composer require akrabat/ip-address-middleware`
 
+In Mezzio, copy `Mezzio/config/ip_address.global.php.dist` into your Mezzio Application `config/autoload` directory as `ip_address.global.php`
+
 ## Usage
 
 In Slim 3:
@@ -78,12 +80,13 @@ $app->get('/', function ($request, $response, $args) {
 });
 ```
 
-In Laminas, add to your `pipeline.php` config at the correct stage, usually just before the `DispatchMiddleware`:
+In Laminas or Mezzio, add to your `pipeline.php` config at the correct stage, usually just before the `DispatchMiddleware`:
 ```php
 # config/pipeline.php
 # using default config
 $app->add(RKA\Middleware\IpAddress::class);
 ```
+If required, update your `.env` file with the environmental variables found in `/config/autoload/ip_address.global.php`.
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.2 || ^8.0",
         "psr/http-message": "^1.0 || ^2.0",
         "psr/http-server-middleware": "^1.0",
-        "psr/container": "^2.0"
+        "psr/container": "^1.0 || ^2.0"
     },
     "require-dev": {
         "laminas/laminas-diactoros": "^2.4 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "psr/http-message": "^1.0 || ^2.0",
-        "psr/http-server-middleware": "^1.0"
+        "psr/http-server-middleware": "^1.0",
+        "psr/container": "^2.0"
     },
     "require-dev": {
         "laminas/laminas-diactoros": "^2.4 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,10 @@
         "psr-4": {
             "RKA\\Middleware\\": "src"
         }
+    },
+    "extra": {
+        "laminas": {
+            "config-provider": "RKA\\Middleware\\Mezzio\\ConfigProvider"
+        }
     }
 }

--- a/src/Mezzio/ConfigProvider.php
+++ b/src/Mezzio/ConfigProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RKA\Middleware\Mezzio;
+
+use RKA\Middleware\IpAddress;
+
+class ConfigProvider
+{
+    public function __invoke(): array
+    {
+        return [
+            'dependencies' => $this->getDependencies(),
+        ];
+    }
+
+    private function getDependencies(): array
+    {
+        return [
+          'factories' => [
+              IpAddress::class => IpAddressFactory::class,
+          ]
+        ];
+    }
+}

--- a/src/Mezzio/IpAddressFactory.php
+++ b/src/Mezzio/IpAddressFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RKA\Middleware\Mezzio;
+
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use RKA\Middleware\IpAddress;
+
+class IpAddressFactory
+{
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function __invoke(ContainerInterface $container): IpAddress
+    {
+        $config = [];
+
+        if ($container->has('config')) {
+            $config = $container->get('config');
+        }
+
+        $checkProxyHeaders = $config['rka']['ip_address']['check_proxy_headers'] ?? false;
+        $trustedProxies = $config['rka']['ip_address']['trusted_proxies'] ?? null;
+        $attributeName = $config['rka']['ip_address']['attribute_name'] ?? null;
+        $headersToInspect = $config['rka']['ip_address']['headers_to_inspect'] ?? [];
+
+        return new IpAddress(
+            $checkProxyHeaders,
+            $trustedProxies,
+            $attributeName,
+            $headersToInspect
+        );
+    }
+}

--- a/src/Mezzio/config/ip_address.global.php.dist
+++ b/src/Mezzio/config/ip_address.global.php.dist
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:disable PSR12.Files.FileHeader.IncorrectOrder
+
+/**
+ * IpAddress Middleware Configuration
+ */
+
+return [
+    'rka' => [
+        'ip_address' => [
+            'check_proxy_headers' => (bool) ($_ENV['IP_ADDRESS_CHECK_PROXY_HEADERS'] ?? false),
+            'trusted_proxies'     => $_ENV['IP_ADDRESS_TRUSTED_PROXIES'] ?? null,
+            'attribute_name'      => $_ENV['IP_ADDRESS_ATTRIBUTE_NAME'] ?? null,
+            'headers_to_inspect'  => explode(',', $_ENV['IP_ADDRESS_HEADERS_TO_INSPECT'] ?? ''),
+        ],
+    ],
+];


### PR DESCRIPTION
Hi @akrabat !

This PR adds some Mezzio files so once we require the library in a Mezzio app, the newly created ConfigProvider is used in the application.

It also adds a Factory so - by copying a dist file into the config/autoload folder in the Mezzio Application - Ip Address Middleware library can be easily configured via an `.env` file.

I added some info in the README file with the steps for a Mezzio installation.

Let me know what you think about this, and please add any improvements you see fit, or let me know and I'll add them.

Thanks!