### PR TITLE
Fix deprecation warning in IpAddress::__construct with PHP 8.4

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
 
     steps:
       - name: Checkout

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -73,7 +73,7 @@ class IpAddress implements MiddlewareInterface
      */
     public function __construct(
         $checkProxyHeaders = false,
-        array $trustedProxies = null,
+        ?array $trustedProxies = null,
         $attributeName = null,
         array $headersToInspect = []
     ) {


### PR DESCRIPTION
Closes #46 

This PR adds PHP 8.4 to the `unit-tests` pipeline, and fixes a deprecation warning thrown with PHP 8.4 due to the use of implicit nullability in `IpAddress::__construct()`.