### PR TITLE
Rightmost IP is the Client IP

### DIFF
--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -147,7 +147,7 @@ class IpAddressTest extends TestCase
         ];
         $ipAddress = $this->simpleRequest($middleware, $env);
 
-        $this->assertSame('192.168.1.3', $ipAddress);
+        $this->assertSame('192.168.1.1', $ipAddress);
     }
 
     public function testXForwardedForIpWithPort()
@@ -159,7 +159,7 @@ class IpAddressTest extends TestCase
         ];
         $ipAddress = $this->simpleRequest($middleware, $env);
 
-        $this->assertSame('192.168.1.3', $ipAddress);
+        $this->assertSame('192.168.1.1', $ipAddress);
     }
 
     public function testProxyIpIsIgnoredWhenNoArgumentsProvided()
@@ -219,7 +219,7 @@ class IpAddressTest extends TestCase
         ];
         $ipAddress = $this->simpleRequest($middleware, $env);
 
-        $this->assertSame('192.168.1.3', $ipAddress);
+        $this->assertSame('192.168.1.1', $ipAddress);
     }
 
     public function testXForwardedForIpWithUntrustedProxy()
@@ -243,7 +243,7 @@ class IpAddressTest extends TestCase
         ];
         $ipAddress = $this->simpleRequest($middleware, $env);
 
-        $this->assertSame('192.0.2.43', $ipAddress);
+        $this->assertSame('198.51.100.17', $ipAddress);
     }
 
     public function testForwardedWithAllOptions()
@@ -255,7 +255,7 @@ class IpAddressTest extends TestCase
         ];
         $ipAddress = $this->simpleRequest($middleware, $env);
 
-        $this->assertSame('192.0.2.60', $ipAddress);
+        $this->assertSame('192.0.2.61', $ipAddress);
     }
 
     public function testForwardedWithWithIpV6()
@@ -365,5 +365,17 @@ class IpAddressTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         new IpAddress(true);
+    }
+
+    public function testXForwardedForIpV6WildCard()
+    {
+        $middleware = new IPAddress(true, ['2600:1f16:1d7b:*:*:*:*:*']);
+        $env = [
+            'REMOTE_ADDR' => '2600:1f16:1d7b:2b00:ed8f:ce7a:8afe:ef7',
+            'HTTP_X_FORWARDED_FOR' => '2600:1f16:1d7b:2b01:ed8f:ce7a:8afe:ef7,50.25.33.55'
+        ];
+        $ipAddress = $this->simpleRequest($middleware, $env);
+
+        $this->assertSame('50.25.33.55', $ipAddress);
     }
 }


### PR DESCRIPTION
Hey Rob!

I created this PR related to this [Issue](https://github.com/akrabat/ip-address-middleware/issues/45).    

I used this links in order to determine that the correct IP is the rightmost IP:
- https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#RequestCustomIPAddresses
- https://adam-p.ca/blog/2022/03/x-forwarded-for/
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For

Let me know if you think this changes should be considered.

Thanks!
