### PR TITLE
Trust the first non-trusted-proxy IP address from the right

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,17 @@ If required, update your `.env` file with the environmental variables found in `
 
 ## Testing
 
-* Code style: ``$ vendor/bin/phpcs``
-* Unit tests: ``$ vendor/bin/phpunit``
-* Code coverage: ``$ vendor/bin/phpunit --coverage-html ./build``
+* Code style: `$ vendor/bin/phpcs`
+* Fix style: `$ vendor/bin/phpcbf`
+* Unit tests: `$ vendor/bin/phpunit`
+* Code coverage: `$ vendor/bin/phpunit --coverage-html ./build`
+
+You can also use Composer scripts:
+
+* Check both: `$ composer check`
+* Code style: `$ composer cs`
+* Fix style: `$ composer cs-fix`
+* Unit tests: `$ composer test`
 
 
 [Master]: https://travis-ci.org/akrabat/ip-address-middleware

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,15 @@
         "laminas": {
             "config-provider": "RKA\\Middleware\\Mezzio\\ConfigProvider"
         }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "cs": "phpcs",
+        "cs-fix": "phpcbf",
+        "code-coverage": "phpunit --coverage-html=coverage ./build",
+        "check": [
+            "@cs",
+            "@test"
+        ]
     }
 }

--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -206,7 +206,7 @@ class IpAddress implements MiddlewareInterface
                         $header,
                         $headerValue,
                         $ipAddress,
-                        $trustedProxies,
+                        $trustedProxies
                     );
                     break;
                 }


### PR DESCRIPTION
When determining the client's IP address from a forwarded header, we need to take the rightmost IP address that is not a trusted proxy as this IP address is the added by the trusted proxy. Any other IP addresses to the left of that one could have been spoofed and so are untrustworthy.

Supersedes #50.

Closes #45 
