### PR TITLE
Set to null if REMOTE_ADDR is empty or invalid

### DIFF
--- a/src/IpAddress.php
+++ b/src/IpAddress.php
@@ -186,6 +186,11 @@ class IpAddress implements MiddlewareInterface
                 $ipAddress = $remoteAddr;
             }
         }
+        if ($ipAddress === null) {
+            // do not continue if there isn't a valid remote address
+            return $ipAddress;
+        }
+
         if (!$this->checkProxyHeaders) {
             // do not check if configured to not check
             return $ipAddress;

--- a/tests/IpAddressTest.php
+++ b/tests/IpAddressTest.php
@@ -22,6 +22,17 @@ class IpAddressTest extends TestCase
         return $attributeValue;
     }
 
+    public function testMissingRemoteAddrSetsTheAttributeToNull()
+    {
+        $middleware = new IPAddress(true, []);
+        $env = [
+            'HTTP_X_FORWARDED_FOR' => '123.4.5.6',
+        ];
+        $ipAddress = $this->simpleRequest($middleware, $env);
+
+        $this->assertSame(null, $ipAddress);
+    }
+
     public function testIpAddressIsSetByRemoteAddrIfCheckProxyHeadersIsFalse()
     {
         $middleware = new IPAddress(false, [], 'IP');


### PR DESCRIPTION
If we don't have a valid REMOTE_ADDR, then there's nothing to do.

Closes #52